### PR TITLE
feat: install postgres pdo driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN curl https://deb.nodesource.com/setup_14.x -o install_node.sh && chmod +x in
   && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install bz2 \
-  && install-php-extensions apcu gd gmp intl opcache pdo_mysql sockets zip  \
+  && install-php-extensions apcu gd gmp intl opcache pdo_mysql pdo_pgsql sockets zip  \
   && apt-get autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The flex recipe for doctrine-bundle installs a docker-compose config
which provides a database service running postgres.  This change makes
it easier for developers to use the postgres database.