### PR TITLE
feat: composer-unused in `php8-review` image

### DIFF
--- a/Dockerfile.php8-review
+++ b/Dockerfile.php8-review
@@ -16,4 +16,7 @@ RUN mv /opt/bin/reviewdog /usr/local/bin
 # add php-tools to search path
 RUN echo "export PATH=$PATH:/opt/php-tools/bin" >> /root/.bashrc
 
+RUN composer global require icanhazstring/composer-unused \
+  && ln -s /root/.config/composer/vendor/bin/composer-unused /usr/local/bin/composer-unused
+
 ENTRYPOINT ["apache2-foreground"]


### PR DESCRIPTION
## Proposed changes

Installs the `composer-unused` command within the `php8-review` tagged image. This tool is going to be setup to run as a git pre-push hook within the devcontainer setup, currently in an open PR draft https://github.com/linkorb/repo-ansible/pull/24

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)