### PR TITLE
fix: install npm in docker containers

### DIFF
--- a/Dockerfile.php7
+++ b/Dockerfile.php7
@@ -39,11 +39,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 
+ENV NODE_MAJOR=20
 # Based on nodesource installation instructions https://github.com/nodesource/distributions#installation-instructions
 RUN mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
   | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update \
   && apt-get install nodejs -y
 

--- a/Dockerfile.php8
+++ b/Dockerfile.php8
@@ -39,11 +39,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 
+ENV NODE_MAJOR=20
 # Based on nodesource installation instructions https://github.com/nodesource/distributions#installation-instructions
 RUN mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
   | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update \
   && apt-get install nodejs -y
 


### PR DESCRIPTION
Missing npm has to deal with the underlying debian container, and the way that the third-party repository sometimes isn't picked up (by my understanding it has to do with version overlap). The upgrade to the node major version fixes this issue across both images, while an explicit `apt-get install npm` works only within the php8 container.


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] feat: non-breaking change which adds new functionality
- [x] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)