### PR TITLE
Switch PHP8 images to PHP83 #8708

### DIFF
--- a/Dockerfile.php8
+++ b/Dockerfile.php8
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.3-apache
 
 EXPOSE 80
 


### PR DESCRIPTION
Making the switch from PHP 8.1 to 8.3.
As far as I see, there are no `Dockerfile` across the organization that uses the PHP 8 images. We use them as part of the Onatal PHP 8 upgrade.