### PR TITLE
feat: add new `php8latest` to the matrix #8708

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,6 +18,7 @@ jobs:
         php:
           - php7
           - php8
+          - php8latest
 
     steps:
     - name: GitHub Environment Variables Action

--- a/Dockerfile.php8latest
+++ b/Dockerfile.php8latest
@@ -1,0 +1,84 @@
+FROM php:8.4-apache
+
+EXPOSE 80
+
+ENV APACHE_RUN_USER    www-data
+ENV APACHE_RUN_GROUP   www-data
+ENV APACHE_LOCK_DIR    /var/lock/apache2
+ENV APACHE_LOG_DIR     /var/log/apache2
+ENV APACHE_PID_FILE    /var/run/apache2/apache2.pid
+ENV APACHE_SERVER_NAME php-docker-base-linkorb
+
+COPY ./php.ini-production "$PHP_INI_DIR/php.ini"
+
+COPY ./apache2.conf      /etc/apache2/apache2.conf
+COPY ./apache-vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+RUN apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install -y --no-install-recommends \
+      curl \
+      git \
+      gosu \
+      iputils-ping \
+      joe \
+      jq \
+      libbz2-dev \
+      openssh-client \
+      software-properties-common \
+      telnet \
+      unzip \
+      vim \
+      zip \
+      ca-certificates \
+      gnupg \
+      tidy \
+      wkhtmltopdf \
+      pdftk \
+      libxml2-dev \
+  && apt-get autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+
+ENV NODE_MAJOR=20
+# Based on nodesource installation instructions https://github.com/nodesource/distributions#installation-instructions
+RUN mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install nodejs -y \
+  && apt-get autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg \
+    | gpg --dearmor >> /usr/share/keyrings/yarnkey.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install yarn \
+  && apt-get autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install bz2 \
+  && install-php-extensions apcu gd gmp intl opcache pdo_mysql pdo_pgsql sockets zip imap mailparse soap mysqli bcmath \
+  && apt-get autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /app/config/secrets/dev \
+  && mkdir -p /app/public/build \
+  && chown -R www-data:www-data /app \
+  && chown -R www-data:www-data /var/www \
+  && a2enmod rewrite \
+  && a2enmod headers
+
+COPY --chown=www-data:www-data index.html /app
+
+WORKDIR /app
+
+USER root

--- a/Dockerfile.php8latest-review
+++ b/Dockerfile.php8latest-review
@@ -1,0 +1,24 @@
+FROM ghcr.io/linkorb/php-docker-base:php8latest
+
+RUN mkdir -p /opt
+
+WORKDIR /opt/
+
+# Do not run Composer as root/super user! See https://getcomposer.org/root for details
+# Aborting as no plugin should be loaded if running as super user is not explicitly allowed
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# install reviewdog
+RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s
+RUN mv /opt/bin/reviewdog /usr/local/bin
+
+RUN composer global require icanhazstring/composer-unused \
+  && ln -s /root/.config/composer/vendor/bin/composer-unused /usr/local/bin/composer-unused
+
+RUN apt-get update && apt-get install -y python3-pip && python3 -m pip install yamllint --break-system-packages
+
+# Caused the appearance of a git untracked index.html file within the GitHub codespace (when image used as
+# the base of a devcontainer)
+RUN rm /app/index.html
+
+ENTRYPOINT ["apache2-foreground"]


### PR DESCRIPTION
I have been testing Onatal on PHP 8.4 for a while now, and now that the official images are available, we can tag a new `php8latest` tag for testing purposes.

Identical Dockerfile as `php8`, but with root image using the latest current PHP version, which makes this a moving target.

```bash
diff Dockerfile.php8 Dockerfile.php8latest
```
```diff
- FROM php:8.3-apache
+ FROM php:8.4-apache
```

## Types of changes

- [x] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
