### PR TITLE
fix: remove php-tools repo in PHP8 container #9236

### DIFF
--- a/Dockerfile.php8-review
+++ b/Dockerfile.php8-review
@@ -9,16 +9,9 @@ WORKDIR /opt/
 # Aborting as no plugin should be loaded if running as super user is not explicitly allowed
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-# install php-tools
-RUN git clone https://github.com/linkorb/php-tools.git
-RUN cd php-tools &&  COMPOSER_MEMORY_LIMIT=-1 /usr/bin/composer install
-
 # install reviewdog
 RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s
 RUN mv /opt/bin/reviewdog /usr/local/bin
-
-# add php-tools to search path globally
-RUN echo "export PATH=$PATH:/opt/php-tools/bin" >> /etc/bash.bashrc
 
 RUN composer global require icanhazstring/composer-unused \
   && ln -s /root/.config/composer/vendor/bin/composer-unused /usr/local/bin/composer-unused


### PR DESCRIPTION
The repository in question has already been archived, and the tooling contained in that repository is incompatible with PHP versions >8.1


## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] feat: non-breaking change which adds new functionality
- [x] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [ ] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

<!-- Please indicate if your PR introduces a breaking change -->
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
