### PR TITLE
chore(php8): drop deprecated INI settings in PHP 8.5 #0000

### DIFF
--- a/php.ini-production
+++ b/php.ini-production
@@ -16,7 +16,6 @@ implicit_flush = Off
 unserialize_callback_func =
 serialize_precision = 17
 disable_functions =
-disable_classes =
 
 zend.enable_gc = On
 
@@ -46,7 +45,6 @@ log_errors = On
 log_errors_max_len = 1024
 ignore_repeated_errors = Off
 ignore_repeated_source = Off
-report_memleaks = On
 track_errors = Off
 html_errors = On
 


### PR DESCRIPTION
We include a php.ini-production file, with sane defaults for all Docker images offered here.

In PHP 8.5, these two INI directives are deprecated:

 - [`report_memleaks`](https://php.watch/codex/report_memleaks#changes-php-8.5): This directive has no effect on regular releases, certainly not on any of the official PHP Docker images, and is only effective on PHP debug builds.
 - [`disable_classes`](https://php.watch/codex/disable_classes#changes-php-8.5): The `php.ini` in this repo contains the same values as defaults (empty list of classes to disable), so we can safely drop references to them.

This PR suggests to remove them, to avoid triggering static analyzers unnecessarily. 

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
