### PR TITLE
fix(Docker): update `ENV` syntax to use `key=value` format #0000

### DIFF
--- a/Dockerfile.php7
+++ b/Dockerfile.php7
@@ -2,12 +2,12 @@ FROM php:7-apache
 
 EXPOSE 80
 
-ENV APACHE_RUN_USER    www-data
-ENV APACHE_RUN_GROUP   www-data
-ENV APACHE_LOCK_DIR    /var/lock/apache2
-ENV APACHE_LOG_DIR     /var/log/apache2
-ENV APACHE_PID_FILE    /var/run/apache2/apache2.pid
-ENV APACHE_SERVER_NAME php-docker-base-linkorb
+ENV APACHE_RUN_USER=www-data
+ENV APACHE_RUN_GROUP=www-data
+ENV APACHE_LOCK_DIR=/var/lock/apache2
+ENV APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
+ENV APACHE_SERVER_NAME=php-docker-base-linkorb
 
 COPY ./php.ini-production "$PHP_INI_DIR/php.ini"
 

--- a/Dockerfile.php8
+++ b/Dockerfile.php8
@@ -2,12 +2,12 @@ FROM php:8.3-apache
 
 EXPOSE 80
 
-ENV APACHE_RUN_USER    www-data
-ENV APACHE_RUN_GROUP   www-data
-ENV APACHE_LOCK_DIR    /var/lock/apache2
-ENV APACHE_LOG_DIR     /var/log/apache2
-ENV APACHE_PID_FILE    /var/run/apache2/apache2.pid
-ENV APACHE_SERVER_NAME php-docker-base-linkorb
+ENV APACHE_RUN_USER=www-data
+ENV APACHE_RUN_GROUP=www-data
+ENV APACHE_LOCK_DIR=/var/lock/apache2
+ENV APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
+ENV APACHE_SERVER_NAME=php-docker-base-linkorb
 
 COPY ./php.ini-production "$PHP_INI_DIR/php.ini"
 


### PR DESCRIPTION
The `Dockerfile` reference[^1] discourages the use of `ENV key val` format, and recommends the `ENV key=val` format.

This commit replaces the `LegacyKeyValueFormat` to the new format to avoid the deprecation notices.

[^1]: https://docs.docker.com/reference/dockerfile/#env

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
