### PR TITLE
fix(build): pin to Debian bookworm-based images instead of `trixie` #0000

### DIFF
--- a/Dockerfile.php8
+++ b/Dockerfile.php8
@@ -1,4 +1,4 @@
-FROM php:8.3-apache
+FROM php:8.3-apache-bookworm
 
 EXPOSE 80
 


### PR DESCRIPTION
One of the packages these images install is the `wkhtmltopdf`, which is used by Onatal's legacy PDF renderer.

Since Debian Trixie was released on 2025 Aug, Docker Hub's PHP builds are based on Trixie. While this works for all other packages, this Debian version drops the then-obsolete `wkhtmltopdf` package:

 - [`wkhtmltopdf` on `bookworm`](https://packages.debian.org/search?suite=bookworm&keywords=wkhtmltopdf)
 - [`wkhtmltopdf` on `trixie` (does not exist)](https://packages.debian.org/search?suite=trixie&keywords=wkhtmltopdf)

To avoid build failures, this changes the PHP images to the ones tagged Debian bookworm.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
