### PR TITLE
fix(reviewdog): fix installation and directly install to `/usr/local/bin` #0000

### DIFF
--- a/Dockerfile.php7-review
+++ b/Dockerfile.php7-review
@@ -14,8 +14,7 @@ RUN git clone https://github.com/linkorb/php-tools.git
 RUN cd php-tools &&  COMPOSER_MEMORY_LIMIT=-1 /usr/bin/composer install
 
 # install reviewdog
-RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s
-RUN mv /opt/bin/reviewdog /usr/local/bin
+RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 
 # add php-tools to search path globally
 RUN echo "export PATH=$PATH:/opt/php-tools/bin" >> /etc/bash.bashrc

--- a/Dockerfile.php8-review
+++ b/Dockerfile.php8-review
@@ -10,8 +10,7 @@ WORKDIR /opt/
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 # install reviewdog
-RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s
-RUN mv /opt/bin/reviewdog /usr/local/bin
+RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 
 RUN composer global require icanhazstring/composer-unused \
   && ln -s /root/.config/composer/vendor/bin/composer-unused /usr/local/bin/composer-unused


### PR DESCRIPTION
The `*-review` images include `reviewdog`, installed by `curl | sh`-ing the `install.sh`.

Following a recent change[^1], the default installation directory has changed.

This updates the `*-review` `Dockerfile`s to be compatible with the `install.sh` changes by directly specifying the installation directory.

Previously, this required manually moving the executable, but from now on, the installation directory is specified as a flag to the `install.sh` script.

[^1]: https://github.com/reviewdog/reviewdog/commit/a547abecbdf6f6c69453be7c04a630ba939c27c0

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
