### PR TITLE
chore(deps): update docker/login-action@v3 to v4 #0000

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
 
     - name: Login to Container Registry ghcr.io
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }} # ghcr logins allow mixed case usernames
@@ -55,7 +55,7 @@ jobs:
     steps:
 
     - name: Login to Container Registry ghcr.io
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }} #ghcr logins allow mixed case usernames


### PR DESCRIPTION
This avoids the GitHub Action workflow run notice about deprecated Nodejs 20 use in `docker/login-action@v3`.

Not pinning to a specific shasum because `docker` is a the real-deal vendor and not some random person.

## Checklist

- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
